### PR TITLE
Add `-I example` to depinst invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - git submodule update --init --depth 1 libs/config
   - git submodule update --init --depth 1 tools/boostdep
   - cp -r $TRAVIS_BUILD_DIR/* libs/function_types
-  - python tools/boostdep/depinst/depinst.py function_types
+  - python tools/boostdep/depinst/depinst.py -I example function_types
   - ./bootstrap.sh
   - ./b2 headers
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - git submodule update --init libs/config
   - git submodule update --init tools/boostdep
   - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\function_types
-  - python tools/boostdep/depinst/depinst.py function_types
+  - python tools/boostdep/depinst/depinst.py -I example function_types
   - bootstrap
   - b2 headers
 


### PR DESCRIPTION
I removed scanning `example` by default in `depinst.py` and instead added an option, `-I/--include`, to specify an additional directory.