### PR TITLE
[CMake] Add minimal cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright 2019 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.FunctionTypes is currently experimental at best
+#       and the interface is likely to change in the future
+
+cmake_minimum_required(VERSION 3.5)
+project(Boost.FunctionTypes  LANGUAGES CXX)
+
+add_library(boost_function_types INTERFACE)
+add_library(Boost::function_types ALIAS boost_function_types)
+
+target_include_directories(boost_function_types INTERFACE include)
+
+target_link_libraries(boost_function_types
+    INTERFACE
+        Boost::config
+        Boost::core
+        Boost::detail
+        Boost::mpl
+        Boost::preprocessor
+        Boost::type_traits
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,15 +5,15 @@
 # NOTE: CMake support for Boost.FunctionTypes is currently experimental at best
 #       and the interface is likely to change in the future
 
-cmake_minimum_required(VERSION 3.5)
-project(Boost.FunctionTypes  LANGUAGES CXX)
+cmake_minimum_required( VERSION 3.5 )
+project( BoostFunctionTypes  LANGUAGES CXX )
 
-add_library(boost_function_types INTERFACE)
-add_library(Boost::function_types ALIAS boost_function_types)
+add_library( boost_function_types INTERFACE )
+add_library( Boost::function_types ALIAS boost_function_types )
 
-target_include_directories(boost_function_types INTERFACE include)
+target_include_directories( boost_function_types INTERFACE include )
 
-target_link_libraries(boost_function_types
+target_link_libraries( boost_function_types
     INTERFACE
         Boost::config
         Boost::core


### PR DESCRIPTION
This cmake file just provides the minimal infrastructure necessary, such that other libraries can get a sensible result from calling


    add_subdirectory( <path-to-boost_function_types> )
    target_link_libraries( <my_lib> PUBLIC Boost::function_types )


provided that all direct and indirect dependencies are also being added via `add_subdirectory` (which can e.g happen via globbing expression).

More information:

* https://groups.google.com/forum/#!topic/boost-developers-archive/9ZdrVbAn1aU


Of course the file can be extended to e.g. build and run tests and support installation, but that is out of scope for this particular PR.

Please note that this is largely orthogonal to the recent addition to b2/boost by peter dimov, which is concerned with providing cmake config files for "classic" boost installations via b2.