### PR TITLE
Added metafunction for testing a property tag

### DIFF
--- a/doc/function_types.qbk
+++ b/doc/function_types.qbk
@@ -837,6 +837,43 @@ values for the same property the value of the rightmost argument is used.
 
 [endsect]
 
+[section:has_property_tag has_property_tag]
+
+  template<class Tag, class PropertyTag> 
+  struct has_property_tag;
+
+[*Header]
+
+  #include <boost/function_types/property_tags.hpp>
+
+[variablelist
+  [[[^Tag]][Possibly compound property tag]]
+  [[[^PropertyTag]][Single property tag]]
+  [[[^has_property_tag<Tag,PropertyTag>]][Test (possibly) compound property tag for single property tag]]
+]
+
+A metafunction for testing that a compound property tag has a particular single
+property tag in its composition. Returns a boolean value of true if the particular single
+property tag is part of the compound property tag, otherwise false.
+
+For convenience there are also individual metafunctions for the built-in property tags of the form
+
+  template<class Tag> 
+  struct has_'name'_property_tag;
+
+which works exactly the same as `has_property_tag`, where name can be
+[^variadic],[^default_cc],[^const],[^volatile],[^cv],or [^null].
+In these individual metafunctions [^const] is short for [^const_qualified],
+[^volatile] is short for [^volatile_qualified],
+[^cv] is short for [^cv_qualified], and [^null] is short for [^null_tag].
+
+[note Testing for the [^null_tag], with either `has_property_tag<Tag,null_tag>`
+or `has_null_property_tag<Tag>`, always tests whether the [^Tag] is the single
+[^null_tag] property_tag.
+]
+
+[endsect]
+
 [endsect] [/ Tag Types]
 
 [/ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ]

--- a/include/boost/function_types/property_tags.hpp
+++ b/include/boost/function_types/property_tags.hpp
@@ -12,6 +12,7 @@
 #include <cstddef>
 
 #include <boost/type_traits/integral_constant.hpp>
+#include <boost/type_traits/is_same.hpp>
 #include <boost/mpl/bitxor.hpp>
 
 
@@ -134,6 +135,20 @@ template<class Tag, class QueryTag> struct extract
   > mask; 
 };
 
+/*
+
+  The following is a metafunction which checks whether a
+  property tag is in a possibly compounded tag type.
+  
+  Here both the possibly compounded tag type and a property tag
+  is given.
+  
+*/
+
+template<class Tag, class PropertyTag> struct has_property_tag
+  : detail::represents_impl<Tag,  PropertyTag>
+{ };
+
 } } // namespace ::boost::function_types
 
 #include <boost/function_types/detail/pp_tags/preprocessed.hpp>
@@ -141,6 +156,43 @@ template<class Tag, class QueryTag> struct extract
 namespace boost { namespace function_types {
 #define BOOST_FT_cc_file <boost/function_types/detail/pp_tags/cc_tag.hpp>
 #include <boost/function_types/detail/pp_loop.hpp>
+
+/*
+
+  The following are metafunctions which check whether the
+  specific property tag is in a possibly compounded tag type.
+  Here only the possibly compounded tag type is given.
+  
+*/
+
+template<class Tag> struct has_property_tag<Tag,null_tag>
+  : ::boost::is_same<Tag, null_tag>
+{ };
+
+template<class Tag> struct has_variadic_property_tag
+  : has_property_tag<Tag,  variadic>
+{ };
+
+template<class Tag> struct has_default_cc_property_tag
+  : has_property_tag<Tag,  default_cc>
+{ };
+
+template<class Tag> struct has_const_property_tag
+  : has_property_tag<Tag,  const_qualified>
+{ };
+
+template<class Tag> struct has_volatile_property_tag
+  : has_property_tag<Tag,  volatile_qualified>
+{ };
+
+template<class Tag> struct has_cv_property_tag
+  : has_property_tag<Tag,  cv_qualified>
+{ };
+
+template<class Tag> struct has_null_property_tag
+  : has_property_tag<Tag,  null_tag>
+{ };
+
 } } // namespace boost::function_types
 
 #endif

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -69,6 +69,10 @@ import testing ;
     [ compile custom_ccs/member_ccs.cpp : <address-model>64:<build>no ]
     [ compile custom_ccs/member_ccs_exact.cpp : <address-model>64:<build>no ]
 
+    # Property tag
+    
+    [ compile custom_ccs/property_tag.cpp ]
+    
     # Code from the examples
 
     [ compile ../example/interpreter_example.cpp ]

--- a/test/custom_ccs/property_tag.cpp
+++ b/test/custom_ccs/property_tag.cpp
@@ -1,0 +1,64 @@
+
+//  (C) Copyright Edward Diener 2019
+//  Use, modification and distribution are subject to the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt).
+
+//------------------------------------------------------------------------------
+
+#include <boost/mpl/assert.hpp>
+#include <boost/function_types/property_tags.hpp>
+
+namespace ft = boost::function_types;
+namespace mpl = boost::mpl;
+
+typedef ft::tag<ft::variadic,ft::non_volatile,ft::non_const,ft::default_cc> tag1;
+typedef ft::tag<ft::const_non_volatile,ft::const_qualified> tag2;
+typedef ft::tag<ft::cv_qualified,ft::variadic> tag3;
+typedef ft::null_tag tag4;
+typedef ft::tag<ft::variadic,ft::volatile_non_const> tag5;
+typedef ft::tag<ft::volatile_qualified,ft::non_const,ft::variadic> tag6;
+typedef ft::tag<ft::non_variadic,ft::const_non_volatile,ft::default_cc> tag7;
+typedef ft::tag<ft::non_cv,ft::default_cc> tag8;
+    
+BOOST_MPL_ASSERT((ft::has_property_tag<tag1, ft::variadic>));
+BOOST_MPL_ASSERT((ft::has_property_tag<tag2, ft::const_qualified>));
+BOOST_MPL_ASSERT((ft::has_property_tag<tag3, ft::cv_qualified>));
+BOOST_MPL_ASSERT((ft::has_property_tag<tag4, ft::null_tag>));
+BOOST_MPL_ASSERT((ft::has_property_tag<tag5, ft::volatile_qualified>));
+BOOST_MPL_ASSERT((ft::has_property_tag<tag6, ft::volatile_qualified>));
+BOOST_MPL_ASSERT((ft::has_property_tag<tag7, ft::const_qualified>));
+BOOST_MPL_ASSERT((ft::has_property_tag<tag8, ft::default_cc>));
+
+BOOST_MPL_ASSERT((ft::has_variadic_property_tag<tag1>));
+BOOST_MPL_ASSERT((ft::has_variadic_property_tag<tag3>));
+BOOST_MPL_ASSERT((ft::has_variadic_property_tag<tag5>));
+BOOST_MPL_ASSERT((ft::has_variadic_property_tag<tag6>));
+BOOST_MPL_ASSERT((ft::has_default_cc_property_tag<tag1>));
+BOOST_MPL_ASSERT((ft::has_default_cc_property_tag<tag7>));
+BOOST_MPL_ASSERT((ft::has_default_cc_property_tag<tag8>));
+BOOST_MPL_ASSERT((ft::has_const_property_tag<tag2>));
+BOOST_MPL_ASSERT((ft::has_const_property_tag<tag3>));
+BOOST_MPL_ASSERT((ft::has_const_property_tag<tag7>));
+BOOST_MPL_ASSERT((ft::has_volatile_property_tag<tag3>));
+BOOST_MPL_ASSERT((ft::has_volatile_property_tag<tag5>));
+BOOST_MPL_ASSERT((ft::has_volatile_property_tag<tag6>));
+BOOST_MPL_ASSERT((ft::has_cv_property_tag<tag3>));
+BOOST_MPL_ASSERT((ft::has_null_property_tag<tag4>));
+
+BOOST_MPL_ASSERT_NOT((ft::has_property_tag<tag1, ft::const_qualified>));
+BOOST_MPL_ASSERT_NOT((ft::has_property_tag<tag2, ft::cv_qualified>));
+BOOST_MPL_ASSERT_NOT((ft::has_property_tag<tag3, ft::null_tag>));
+BOOST_MPL_ASSERT_NOT((ft::has_property_tag<tag4, ft::volatile_qualified>));
+BOOST_MPL_ASSERT_NOT((ft::has_property_tag<tag5, ft::const_qualified>));
+BOOST_MPL_ASSERT_NOT((ft::has_property_tag<tag6, ft::default_cc>));
+BOOST_MPL_ASSERT_NOT((ft::has_property_tag<tag7, ft::variadic>));
+BOOST_MPL_ASSERT_NOT((ft::has_property_tag<tag8, ft::volatile_qualified>));
+
+BOOST_MPL_ASSERT_NOT((ft::has_variadic_property_tag<tag2>));
+BOOST_MPL_ASSERT_NOT((ft::has_default_cc_property_tag<tag6>));
+BOOST_MPL_ASSERT_NOT((ft::has_const_property_tag<tag4>));
+BOOST_MPL_ASSERT_NOT((ft::has_const_property_tag<tag5>));
+BOOST_MPL_ASSERT_NOT((ft::has_volatile_property_tag<tag7>));
+BOOST_MPL_ASSERT_NOT((ft::has_cv_property_tag<tag1>));
+BOOST_MPL_ASSERT_NOT((ft::has_null_property_tag<tag8>));


### PR DESCRIPTION
I have a need for testing whether a possibly compound property tag has a built-in individual property tag in its composition. Although the function_types library has a template for creating compound property tags, it has never had a documented metafunction for testing whether an single property tag is part of the composition of the compound property tag. So I created such a metafunction, along with a set of convenient individual metafunctioins for the built-in property tags, created some tests, and added some documentation for these new metafunctions. These additions do not affect the current function_types library functionality in any way, but may be helpful to other programmers who work with property tags in function_types.