### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,18 @@ branches:
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0,msvc-12.0,msvc-14.0
+      TOOLSET: msvc-10.0,msvc-11.0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      TOOLSET: msvc-12.0,msvc-14.0
+      ADDRESS_MODEL: 32,64
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       TOOLSET: msvc-14.1
+      CXXSTD: 14,17
+      ADDRESS_MODEL: 32,64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      TOOLSET: msvc-14.2
+      CXXSTD: 14,17
+      ADDRESS_MODEL: 32,64
 
 install:
   - cd ..

--- a/example/result_of.hpp
+++ b/example/result_of.hpp
@@ -57,7 +57,7 @@ namespace example
       typedef typename F::template result<Desc>::type type;
     };
 
-#if !BOOST_WORKAROUND(__BORLANDC__,BOOST_TESTED_AT(0x564))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC,BOOST_TESTED_AT(0x564))
     template<typename F> 
     struct result_member_template< F, F(void) > 
     { 

--- a/include/boost/function_types/components.hpp
+++ b/include/boost/function_types/components.hpp
@@ -22,7 +22,7 @@
 #include <boost/mpl/integral_c.hpp>
 #include <boost/mpl/vector/vector0.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, <= 0x565)
+#if BOOST_WORKAROUND(BOOST_BORLANDC, <= 0x565)
 #   include <boost/type_traits/remove_cv.hpp>
 
 #   include <boost/mpl/identity.hpp>
@@ -76,14 +76,14 @@ namespace boost
     namespace detail 
     {
       template<typename T, typename L> struct components_impl;
-#if BOOST_WORKAROUND(__BORLANDC__, <= 0x565)
+#if BOOST_WORKAROUND(BOOST_BORLANDC, <= 0x565)
       template<typename T, typename OrigT, typename L> struct components_bcc;
 #endif
     }
 
     template<typename T, typename ClassTypeTransform> 
     struct components
-#if !BOOST_WORKAROUND(__BORLANDC__, <= 0x565)
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, <= 0x565)
       : detail::components_impl<T, ClassTypeTransform>
 #else
       : detail::components_bcc<typename remove_cv<T>::type,T,
@@ -255,7 +255,7 @@ namespace boost
           typename detail::class_transform<C,L>::type > types;
     };
 
-#if !BOOST_WORKAROUND(__BORLANDC__, <= 0x565)
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, <= 0x565)
 #   define BOOST_FT_variations BOOST_FT_pointer|BOOST_FT_member_pointer
 
     template<typename T, class C, typename L>

--- a/include/boost/function_types/config/compiler.hpp
+++ b/include/boost/function_types/config/compiler.hpp
@@ -91,11 +91,11 @@
 #     define __fastcall __attribute__((__fastcall__))
 #   endif
 
-#elif defined(__BORLANDC__)
+#elif defined(BOOST_BORLANDC)
 
-#   if __BORLANDC__ < 0x550
+#   if BOOST_BORLANDC < 0x550
 #     error "unsupported compiler version"
-#   elif __BORLANDC__ > 0x565
+#   elif BOOST_BORLANDC > 0x565
 #     pragma message("WARNING: library untested with this compiler version")
 #   endif
 

--- a/include/boost/function_types/detail/classifier.hpp
+++ b/include/boost/function_types/detail/classifier.hpp
@@ -30,7 +30,7 @@ template<bits_t Flags, bits_t CCID, std::size_t Arity> struct encode_charr
   >::type type;
 };
 
-#if defined(BOOST_MSVC) || (defined(__BORLANDC__) && !defined(BOOST_DISABLE_WIN32))
+#if defined(BOOST_MSVC) || (defined(BOOST_BORLANDC) && !defined(BOOST_DISABLE_WIN32))
 #   define BOOST_FT_DECL __cdecl
 #else
 #   define BOOST_FT_DECL /**/

--- a/include/boost/function_types/detail/cv_traits.hpp
+++ b/include/boost/function_types/detail/cv_traits.hpp
@@ -12,7 +12,7 @@
 #include <cstddef>
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, <= 0x582)
+#if BOOST_WORKAROUND(BOOST_BORLANDC, <= 0x582)
 #   include <boost/type_traits/remove_cv.hpp>
 #   include <boost/type_traits/remove_pointer.hpp>
 #   include <boost/type_traits/remove_reference.hpp>
@@ -22,7 +22,7 @@
 
 namespace boost { namespace function_types { namespace detail {
 
-#if !BOOST_WORKAROUND(__BORLANDC__, <= 0x582)
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, <= 0x582)
 
 template<typename T> struct cv_traits 
 { typedef non_cv tag; typedef T type; };


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.