### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -7,12 +7,12 @@ import project ;
 
 project /boost/function_types
     : common-requirements
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/detail//boost_detail
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/detail//boost_detail
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -5,22 +5,25 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/detail//boost_detail
+    /boost/mpl//boost_mpl
+    /boost/preprocessor//boost_preprocessor
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/function_types
     : common-requirements
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/detail//boost_detail
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_function_types ]
+    [ alias boost_function_types : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_function_types example test ]
     ;
 
 call-if : boost-library function_types
     : install boost_function_types
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,26 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/function_types
+    : common-requirements
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/detail//boost_detail
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_function_types ]
+    [ alias all : boost_function_types example test ]
+    ;
+
+call-if : boost-library function_types
+    : install boost_function_types
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/function_types

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/function_types
     : common-requirements

--- a/example/Jamfile
+++ b/example/Jamfile
@@ -1,10 +1,12 @@
 
-# (C) Copyright Tobias Schwinger 
+# (C) Copyright Tobias Schwinger
 #
 # Use, modification and distribution are subject to the Boost Software License,
 # Version 1.0. (See http://www.boost.org/LICENSE_1_0.txt).
 
 #-------------------------------------------------------------------------------
+
+project : requirements <library>/boost/function_types//boost_function_types ;
 
 exe  interpreter_example     : interpreter_example.cpp
     : <library>/boost/tokenizer//boost_tokenizer
@@ -15,7 +17,7 @@ exe  result_of_example       : result_of_example.cpp   ;
 
 exe  interface_example       : interface_example.cpp   ;
 
-exe  fast_mem_fn_example     : fast_mem_fn_example.cpp 
+exe  fast_mem_fn_example     : fast_mem_fn_example.cpp
     : <include>. # needed for Boost.PP file iteration with some compilers
       <library>/boost/timer//boost_timer
       <library>/boost/bind//boost_bind

--- a/example/Jamfile
+++ b/example/Jamfile
@@ -6,14 +6,20 @@
 
 #-------------------------------------------------------------------------------
 
-exe  interpreter_example     : interpreter_example.cpp ;
+exe  interpreter_example     : interpreter_example.cpp
+    : <library>/boost/tokenizer//boost_tokenizer
+      <library>/boost/lexical_cast//boost_lexical_cast
+    ;
 
 exe  result_of_example       : result_of_example.cpp   ;
 
 exe  interface_example       : interface_example.cpp   ;
 
 exe  fast_mem_fn_example     : fast_mem_fn_example.cpp 
-    : <include>. ; # needed for Boost.PP file iteration with some compilers
+    : <include>. # needed for Boost.PP file iteration with some compilers
+      <library>/boost/timer//boost_timer
+      <library>/boost/bind//boost_bind
+    ;
 
 exe  macro_type_args_example : macro_type_args_example.cpp ;
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -75,12 +75,14 @@ import testing ;
     
     # Code from the examples
 
-    [ compile ../example/interpreter_example.cpp ]
+    [ compile ../example/interpreter_example.cpp : <library>/boost/tokenizer//boost_tokenizer <library>/boost/lexical_cast//boost_lexical_cast ]
     [ compile ../example/result_of_example.cpp ]
     [ compile ../example/interface_example.cpp ]
     [ compile ../example/fast_mem_fn_example.cpp 
       # needed for Boost.PP file iteration with some compilers
       : <include>../example
+        <library>/boost/timer//boost_timer
+        <library>/boost/bind//boost_bind
     ]
     [ compile ../example/macro_type_args_example.cpp ]
     ;

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -1,5 +1,5 @@
 
-# (C) Copyright Tobias Schwinger 
+# (C) Copyright Tobias Schwinger
 #
 # Use, modification and distribution are subject to the Boost Software License,
 # Version 1.0. (See http://www.boost.org/LICENSE_1_0.txt).
@@ -8,8 +8,10 @@
 
 import testing ;
 
+project : requirements <library>/boost/function_types//boost_function_types ;
+
 {
-  test-suite function_types : 
+  test-suite function_types :
 
     # Classification
 
@@ -28,7 +30,7 @@ import testing ;
     # [ compile classification/is_cv_function.cpp ]
 
     # Decomposition
-    
+
     [ compile decomposition/components.cpp ]
     [ compile decomposition/result_type.cpp ]
     [ compile decomposition/function_arity.cpp ]
@@ -70,15 +72,15 @@ import testing ;
     [ compile custom_ccs/member_ccs_exact.cpp : <address-model>64:<build>no ]
 
     # Property tag
-    
+
     [ compile custom_ccs/property_tag.cpp ]
-    
+
     # Code from the examples
 
     [ compile ../example/interpreter_example.cpp : <library>/boost/tokenizer//boost_tokenizer <library>/boost/lexical_cast//boost_lexical_cast ]
     [ compile ../example/result_of_example.cpp ]
     [ compile ../example/interface_example.cpp ]
-    [ compile ../example/fast_mem_fn_example.cpp 
+    [ compile ../example/fast_mem_fn_example.cpp
       # needed for Boost.PP file iteration with some compilers
       : <include>../example
         <library>/boost/timer//boost_timer


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.