### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -22,7 +22,6 @@ type_traits
 # Secondary dependencies
 
 assert
-static_assert
 throw_exception
 predef
 utility


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.